### PR TITLE
Add conversation history to AI chat

### DIFF
--- a/api/SelfCare.Api/Models/DTOs/ChatRequest.cs
+++ b/api/SelfCare.Api/Models/DTOs/ChatRequest.cs
@@ -6,6 +6,13 @@ public class ChatRequest
     public string RoutineType { get; set; } = "Morning";
     public List<ChatStepInfo> Steps { get; set; } = [];
     public List<ChatProductInfo> Products { get; set; } = [];
+    public List<ChatHistoryMessage> History { get; set; } = [];
+}
+
+public class ChatHistoryMessage
+{
+    public string Role { get; set; } = "";
+    public string Content { get; set; } = "";
 }
 
 public class ChatProductInfo

--- a/api/SelfCare.Api/Services/ChatService.cs
+++ b/api/SelfCare.Api/Services/ChatService.cs
@@ -59,11 +59,17 @@ public class ChatService : IChatService
 
         var chatClient = client.GetChatClient(deploymentName);
 
-        var messages = new List<ChatMessage>
+        var messages = new List<ChatMessage> { new SystemChatMessage(systemPrompt) };
+
+        foreach (var msg in request.History)
         {
-            new SystemChatMessage(systemPrompt),
-            new UserChatMessage(request.Message)
-        };
+            if (msg.Role == "user")
+                messages.Add(new UserChatMessage(msg.Content));
+            else if (msg.Role == "assistant")
+                messages.Add(new AssistantChatMessage(msg.Content));
+        }
+
+        messages.Add(new UserChatMessage(request.Message));
 
         var completion = await chatClient.CompleteChatAsync(messages, new ChatCompletionOptions
         {

--- a/src/app/pages/routine/routine.page.ts
+++ b/src/app/pages/routine/routine.page.ts
@@ -397,7 +397,7 @@ export class RoutinePage implements OnInit {
 
     if (this.aiChatService.isConfigured()) {
       this.aiChatService
-        .sendMessage(message, this.steps, this.routineType, this.products)
+        .sendMessage(message, this.steps, this.routineType, this.products, this.chatMessages)
         .subscribe({
           next: (response) => {
             this.chatMessages.push(response);

--- a/src/app/services/ai-chat.service.ts
+++ b/src/app/services/ai-chat.service.ts
@@ -22,6 +22,10 @@ interface ChatApiRequest {
     category: string;
     description: string | null;
   }>;
+  history: Array<{
+    role: string;
+    content: string;
+  }>;
 }
 
 interface ChatApiResponse {
@@ -57,7 +61,8 @@ export class AiChatService {
     userMessage: string,
     steps: RoutineStep[],
     routineType: string,
-    products: Product[] = []
+    products: Product[] = [],
+    chatHistory: ChatMessage[] = []
   ): Observable<ChatMessage> {
     const body: ChatApiRequest = {
       message: userMessage,
@@ -74,6 +79,9 @@ export class AiChatService {
         category: p.category,
         description: p.description || null,
       })),
+      history: chatHistory
+        .filter(m => m.role === 'user' || m.role === 'assistant')
+        .map(m => ({ role: m.role, content: m.content })),
     };
 
     return this.http.post<ChatApiResponse>(this.apiUrl, body).pipe(


### PR DESCRIPTION
Closes #17

## Summary
- Added `History` field to `ChatRequest` DTO with `ChatHistoryMessage` (role + content)
- Updated `ChatService` to include prior conversation messages in the GPT call
- Updated frontend `AiChatService` to pass `chatMessages` array to the API
- Updated `routine.page.ts` to pass chat history when calling `sendMessage`

## How it works
The frontend already maintained the full `chatMessages` array — it just never sent it. Now each API call includes the conversation history, so GPT sees: system prompt → prior user/assistant messages → current user message.

## Test plan
- [ ] Send multiple messages in chat and verify the AI references earlier messages
- [ ] Verify first message still works (empty history)
- [ ] Check long conversations don't break (token limits)

https://claude.ai/code/session_01YQ2JBTUXuTsR92zY6xy9bJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQ2JBTUXuTsR92zY6xy9bJ)_